### PR TITLE
Change the object tracker's update_tracker method to return evicted fish

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,7 +86,14 @@ def main():
 
 
         # tracked_fish = 2d list shape(n, 4) of tracked objects in the format [fish_id, class, score, box]
-        tracked_fish, tracklets = ot.update_tracker(classes, scores, boxes, frame)
+        tracked_fish, evicted_fish = ot.update_tracker(classes, scores, boxes, frame)
+
+        for fish in evicted_fish:
+            # iterate over all fish we have aged out and are no longer tracking.
+            # at this point, you can make calculations over the lifetime of the
+            # tracked object, like....
+            moveX = fish.center[0] - fish.first_center[0]
+            moveY = fish.center[1] - fish.first_center[1]
 
         print(ot.tracked_objects)
         #print(len(tracked_fish))

--- a/objectTracker.py
+++ b/objectTracker.py
@@ -125,15 +125,13 @@ class objectTracker:
             self.tracked_objects.append(new_fish)
 
         ret = []
+        evicted = []
 
-        to = []
         # filter out dead tracked items, append ret with passing tracked_objects, and return ret
         for obj in self.tracked_objects:
-            to.append(obj.fish_id) 
-
             if obj.frames_without_hit >= self.max_age:
                 self.tracked_objects.remove(obj)
-                #compute difference between first center object and last one
+                evicted.append(obj)
                 continue
 
             if (obj.frames_without_hit < 1) and (obj.hit_streak >= self.min_hits or self.frame_count <= self.min_hits):
@@ -141,8 +139,8 @@ class objectTracker:
                 ret.append(r)
 
         if len(ret) == 0:
-            return np.empty((0,4)), to
-        return ret, to
+            return np.empty((0,4)), evicted
+        return ret, evicted
 
 
 class direction:


### PR DESCRIPTION
In order to calculate the overall/net direction a fish has moved, it would be useful for callers of the `objectTracker`'s `update_tracker` method to get a list of fish when we decide to stop tracking them. I noticed that (currently anyway) the second item being returned from the `update_tracker` method wasn't really being used, so I kinda appropriated that. Let me know if it's an issue.

Merge/edit at will.

Nice code btw @jackrogers47.